### PR TITLE
Tâche Zip - correction du mois affiché

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -205,7 +205,8 @@ gulp.task('uncss', function () {
 // Tâche "zip" = création de fichier .zip du projet
 gulp.task('zip', function () {
   var d = new Date();
-  var date = d.getFullYear() + '-' + d.getMonth() + '-' + d.getDate() + '-' + d.getHours() + 'h' + d.getMinutes();
+  var mois = d.getMonth() + 1;
+  var date = d.getFullYear() + '-' + mois + '-' + d.getDate() + '-' + d.getHours() + 'h' + d.getMinutes();
   return gulp.src(destination + '/**/')
       .pipe(plugins.zip('Alsacreations-' + project + '-' + zipName + '-' + date + '.zip'))
       .pipe(gulp.dest('./'));


### PR DESCRIPTION
Le mois retourné par la fonction JavaScript Date.getMonth() retourne un résultat entre 0 et 11.
Correction faite pour afficher un mois compréhensible par tous.

Documentation JS : https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/Date/getMonth