### PR TITLE
package.json – ajout de la dépendance à Bower

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,10 @@
   "version": "2.0.6",
   "description": "base de départ pour des projets HTML / CSS / JS dans un environnement nodeJS, Gulp et KNACSS",
   "devDependencies": {
-    "gulp": "^3.9.0",
+    "bower": "^1.7.2",
     "browser-sync": "^2.10.0",
     "del": "^2.2.0",
+    "gulp": "^3.9.0",
     "gulp-autoprefixer": "^3.1.0",
     "gulp-changed": "^1.3.0",
     "gulp-concat": "^2.6.0",


### PR DESCRIPTION
Ce repo utilise une dépendance qui n'est pas présente au sein du package.json : bower
(fichiers `.bowerrc` & `bower.json`)
Cette dépendance n'est pas forcément toujours installée chez l'utilisateur, il est à mon avis nécessaire de l'ajouter au sein des dépendances de développement.

Au passage, j'ai juste déplacé l'appel à la dépendance `gulp`. L'objet `devDependencies` est généralement organisé par ordre alphabétique (l'ordre est vérifié à chaque installation de nouveau package par NPM, cela évitera une modification inutile à la prochaine installation de dépendance).