### PR TITLE
Changement du script d'installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ En clair, récupérez ce repo :
 ### Prenez une Bretzel
 
 Au sein de votre dossier de projet :
-- lancez `npm run setup` pour installer les plugins nécessaires, les dépendances et lancer une première fois Gulp
+- lancez `npm install` pour installer les plugins nécessaires, les dépendances et lancer une première fois Gulp
 
 ### Mangez votre Bretzel !
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "gulp-zip": "^3.0.2"
   },
   "scripts": {
-    "setup": "npm install && bower install && gulp"
+    "preinstall": "gulp pull",
+    "postinstall": "bower install && gulp"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "gulp-zip": "^3.0.2"
   },
   "scripts": {
-    "preinstall": "gulp pull",
     "postinstall": "bower install && gulp"
   },
   "repository": {


### PR DESCRIPTION
Cette modification permet de ne plus lancer un nom de script personnalisé pour l'installation des dépendances et des scripts nécessaire au fonctionnement du projet.

En utilisant les scripts pre- et post- install de NPM, à chaque installation : 
- _npm_ lance automatiquement un `git pull` pour récupérer les dernières versions des fichiers de dépendance avant de faire un `npm install`.
- _npm_ lance automatiquement un `bower install` et un `gulp` après avoir fini le `npm install`