### PR TITLE
Modifs et améliorations sur le Styleguide

### DIFF
--- a/src/assets/styleguide/patterns/01-design.md
+++ b/src/assets/styleguide/patterns/01-design.md
@@ -4,23 +4,23 @@
 
   <div class="sg-example"><div class="sg-canvas">
       <div class="sg-color">
-        <div class="sg-color-item base-color"><span>@base-color</span></div>
-        <div class="sg-color-item primary-color"><span>@primary-color</span></div>
-        <div class="sg-color-item secondary-color"><span>@secondary-color</span></div>
+        <div class="sg-color-item base-color"><span>$base-color</span></div>
+        <div class="sg-color-item primary-color"><span>$primary-color</span></div>
+        <div class="sg-color-item secondary-color"><span>$secondary-color</span></div>
       </div>
       <div class="sg-color">
-        <div class="sg-color-item headings-color"><span>@headings-color</span></div>
-        <div class="sg-color-item headings-1-color"><span>@headings-1-color</span></div>
-        <div class="sg-color-item headings-2-color"><span>@headings-2-color</span></div>
-        <div class="sg-color-item headings-3-color"><span>@headings-3-color</span></div>
+        <div class="sg-color-item headings-color"><span>$headings-color</span></div>
+        <div class="sg-color-item headings-1-color"><span>$headings-1-color</span></div>
+        <div class="sg-color-item headings-2-color"><span>$headings-2-color</span></div>
+        <div class="sg-color-item headings-3-color"><span>$headings-3-color</span></div>
       </div>
       <div class="sg-color">
-        <div class="sg-color-item base-color-link"><span>@base-color-link</span></div>
-        <div class="sg-color-item base-color-link-hover"><span>@base-color-link-hover</span></div>
+        <div class="sg-color-item base-color-link"><span>$base-color-link</span></div>
+        <div class="sg-color-item base-color-link-hover"><span>$base-color-link-hover</span></div>
       </div>
       <div class="sg-color">
-        <div class="sg-color-item base-background"><span>@base-background</span></div>
-        <div class="sg-color-item primary-background"><span>@primary-background</span></div>
-        <div class="sg-color-item secondary-background"><span>@secondary-background</span></div>
+        <div class="sg-color-item base-background"><span>$base-background</span></div>
+        <div class="sg-color-item primary-background"><span>$primary-background</span></div>
+        <div class="sg-color-item secondary-background"><span>$secondary-background</span></div>
       </div>
   </div></div>

--- a/src/assets/styleguide/patterns/02-typography.md
+++ b/src/assets/styleguide/patterns/02-typography.md
@@ -4,19 +4,19 @@
 
   <div class="sg-example"><div class="sg-canvas">
       <div class="sg-font-common">
-          <code>@font-stack-common</code><br>
+          <code>$font-stack-common</code><br>
           ABCDEFGHIJKLMNOPQRSTUVWXYZ<br>
           abcdefghijklmnopqrstuvwxyz<br>
           0123456789
       </div>
       <div class="sg-font-headings">
-          <code>@font-stack-headings</code><br>
+          <code>$font-stack-headings</code><br>
           ABCDEFGHIJKLMNOPQRSTUVWXYZ<br>
           abcdefghijklmnopqrstuvwxyz<br>
           0123456789
       </div>
       <div class="sg-font-monospace">
-          <code>@font-stack-monospace</code><br>
+          <code>$font-stack-monospace</code><br>
           ABCDEFGHIJKLMNOPQRSTUVWXYZ<br>
           abcdefghijklmnopqrstuvwxyz<br>
           0123456789

--- a/src/assets/styleguide/patterns/03-inline-elements.md
+++ b/src/assets/styleguide/patterns/03-inline-elements.md
@@ -47,7 +47,9 @@ L'élément `<mark>`&nbsp;représente du texte surligné, c'est-à-dire du texte
 
 ### Abbr
 
-L'élément `<abbr>`&nbsp;représente une abréviation et permet de façon optionnelle d'en fournir une description complète. S'il est présent, l'attribut title doit contenir cette même description complète et rien d'autre.
+L'élément `<abbr>`&nbsp;représente une abréviation et permet de façon optionnelle d'en fournir une description complète. S'il est présent, l'attribut title doit contenir cette même description complète et rien d'autre. S'il y a plusieurs occurences de la même abréviation dans une page, l'attribut title ne doit être présent que sur la 1ère occurence.
 
     @example
-    <p>Ce document a été conçu avec du code <abbr title="HyperText Markup Language">HTML</abbr>.</p>
+    <p>Ce document a été conçu avec du code <abbr title="HyperText Markup Language">HTML</abbr>. Voir la définition de
+    <abbr>HTML</abbr>
+    sur <a href="https://fr.wikipedia.org/wiki/Hypertext_Markup_Language">Wikipedia</a>.</p>

--- a/src/assets/styleguide/patterns/05-table.md
+++ b/src/assets/styleguide/patterns/05-table.md
@@ -6,8 +6,8 @@
     <table>
         <thead>
             <tr>
-                <th>Ville</th>
-                <th>Pays</th>
+                <th scope="col">Ville</th>
+                <th scope="col">Pays</th>
             </tr>
         </thead>
         <tfoot>
@@ -35,18 +35,18 @@
         <thead>
             <tr>
                 <th></th>
-                <th>Ville</th>
-                <th>Pays</th>
+                <th scope="col">Ville</th>
+                <th scope="col">Pays</th>
             </tr>
         </thead>
         <tbody>
             <tr>
-                <th>Jour 1</th>
+                <th scope="row">Jour 1</th>
                 <td>Strasbourg</td>
                 <td>France</td>
             </tr>
             <tr>
-                <th>Jour 2</th>
+                <th scope="row">Jour 2</th>
                 <td>Berlin</td>
                 <td>Allemagne</td>
             </tr>

--- a/src/assets/styleguide/patterns/06-button.md
+++ b/src/assets/styleguide/patterns/06-button.md
@@ -1,17 +1,24 @@
 ## Éléments cliquables
 
-### Boutons
+### Liens ayant le style d'un bouton
 
-Les classes CSS <code>.btn</code>, <code>.btn-primary</code>, <code>.btn-secondary</code> et <code>.btn-tertiary</code> peuvent être appliquées sur les éléments suivants : `<a> <button> <input type="submit">`
+La classe CSS <code>.btn</code> peut être appliquée sur l'élément `<a>` pour le styler visuellement comme les éléments `<button>` et `<input type="submit">`.  
+Les classes <code>.btn-primary</code>, <code>.btn-secondary</code>
+ou <code>.btn-tertiary</code>
+peuvent être ajoutées pour le styler comme le serait un bouton de formulaire ayant l'une de ces classes.  
+<em>Note</em>&nbsp;: ne pas utiliser un lien là où il faudrait utiliser un bouton de formulaire&nbsp;!
 
     @example
-    <a class="btn btn-primary" href="#">Primary</a>
-    <a class="btn btn-secondary" href="#">Secondary</a>
-    <a class="btn btn-tertiary" href="#">Tertiary</a>
+    p Link that looks like a button with style:
+      | <a class="btn" href="#">Default</a>
+      | <a class="btn btn-primary" href="#">Primary</a>
+      | <a class="btn btn-secondary" href="#">Secondary</a>
+      | <a class="btn btn-tertiary" href="#">Tertiary</a>
 
 ### Boutons avec une icône
 
-La classe CSS <code>.icon-</code> peut être appliquée sur les éléments suivants : `<i>`. 
+La classe CSS <code>.icon-</code>
+peut être appliquée sur les éléments suivants : `<i>`. 
 
     @example
     <a class="btn btn-primary" href="#"><i class="icon-arrow" aria-hidden="true"></i>Primary</a>

--- a/src/assets/styleguide/patterns/07-forms.md
+++ b/src/assets/styleguide/patterns/07-forms.md
@@ -76,7 +76,7 @@ Les classes CSS `.btn-primary`, `.btn-secondary` ou `.btn-tertiary` peuvent êtr
     @example
     <p class="form-item">
       <label for="a5">Votre message</label>
-      <textarea id="a5" class="form-txt" row="6"></textarea>
+      <textarea id="a5" class="form-txt" rows="6"></textarea>
     </p>
 
 

--- a/src/assets/styleguide/patterns/07-forms.md
+++ b/src/assets/styleguide/patterns/07-forms.md
@@ -146,7 +146,7 @@ Styles pour les 3 états suivants : succès, erreur ou avertissement.
 
 
 ### Choix multiple
-L'élément `<fieldset>`&nbsp;est utilisé pour regroupé plusieurs éléments de formulaire, par exemple plusieurs cases à cocher.  
+L'élément `<fieldset>`&nbsp;est utilisé pour regrouper plusieurs éléments de formulaire, par exemple plusieurs cases à cocher.  
 Un élément `<legend>`&nbsp; unique doit être son 1er enfant.
 
     @example

--- a/src/assets/styleguide/patterns/07-forms.md
+++ b/src/assets/styleguide/patterns/07-forms.md
@@ -4,6 +4,7 @@
 La classe CSS `.form-txt`&nbsp;peut s'appliquer sur les champs texte de type : `text`, `password`, `datetime-local`, `date`, `month`, `time`, `week`, `number`, `email`, `url`, `search`, `tel`, and `color`.
 
     @example
+    <p>Les champs marqués d'un * sont obligatoires</p>
     <p class="form-item">
       <label for="a0">Champ texte</label>
       <input type="text" class="form-txt" id="a0">
@@ -25,18 +26,23 @@ La classe CSS `.form-txt`&nbsp;peut s'appliquer sur les champs texte de type : `
     </p>
 
     <p class="form-item">
-      <label for="a2-3">Champ texte (date)</label>
+      <label for="a2-3">Champ de type date</label>
       <input type="date" class="form-txt" id="a2-3">
     </p>
 
     <p class="form-item">
-      <label for="a2-4">Champ texte (time)</label>
+      <label for="a2-4">Champ de type time</label>
       <input type="time" class="form-txt" id="a2-4">
     </p>
 
     <p class="form-item">
-      <label for="a2-5">Champ texte (password)</label>
+      <label for="a2-5">Champ de type password</label>
       <input type="password" class="form-txt" id="a2-5">
+    </p>
+
+    <p class="form-item">
+      <label for="a2-6">Champ recherche</label>
+      <input type="search" class="form-txt" id="a2-6">
     </p>
 
 
@@ -85,21 +91,24 @@ Styles pour les 3 états suivants : succès, erreur ou avertissement.
 
     @example
     <p class="form-item has-error">
-      <label for="a0-0">Champ texte (error)</label>
-      <input type="text" class="form-txt" id="a0-0">
-      <span class="form-help">Ici mon message d'erreur</span>
+      <label for="a0-0">Champ texte (error)
+        <input type="text" class="form-txt" id="a0-0">
+        <span class="form-help">Ici mon message d'erreur</span>
+      </label>
     </p>
 
     <p class="form-item has-warning">
-      <label for="a0-1">Champ texte (warning)</label>
-      <input type="text" class="form-txt" id="a0-1">
-      <span class="form-help">Ici mon message d'avertissement</span>
+      <label for="a0-1">Champ texte (warning)
+        <input type="text" class="form-txt" id="a0-1">
+        <span class="form-help">Ici mon message d'avertissement</span>
+      </label>
     </p>
 
     <p class="form-item has-success">
-      <label for="a0-2">Champ texte (success)</label>
-      <input type="text" class="form-txt" id="a0-2">
-      <span class="form-help">Ici mon message pour valider</span>
+      <label for="a0-2">Champ texte (success)
+        <input type="text" class="form-txt" id="a0-2">
+        <span class="form-help">Ici mon message pour valider</span>
+      </label>
     </p>
 
 ### Liste déroulante
@@ -137,21 +146,22 @@ Styles pour les 3 états suivants : succès, erreur ou avertissement.
 
 
 ### Choix multiple
-L'élément `<fieldset>`&nbsp;est utilisé pour regroupé plusieurs case à cocher.
+L'élément `<fieldset>`&nbsp;est utilisé pour regroupé plusieurs éléments de formulaire, par exemple plusieurs cases à cocher.  
+Un élément `<legend>`&nbsp; unique doit être son 1er enfant.
 
     @example
     <fieldset>
         <legend>Un choix multiple avec bouton radio</legend>
         <p class="form-item-radio">
-            <input class="form-radio" type="radio" id="br1" name="br" value="1" checked="">
-            <label for="br1">Une réponse possible (selected)</label>
+            <input class="form-radio" type="radio" id="br1" name="br" value="1" checked><!-- NOTE: or checked="checked" or checked="" -->
+            <label for="br1">Une réponse possible (checked)</label>
         </p>
         <p class="form-item-radio">
             <input class="form-radio" type="radio" id="br2" name="br" value="2">
             <label for="br2">Une réponse possible</label>
         </p>
         <p class="form-item-radio">
-            <input class="form-radio" type="radio" id="br3" name="br" value="3" disabled="">
+            <input class="form-radio" type="radio" id="br3" name="br" value="3" disabled>
             <label for="br3">Réponse (disabled)</label>
         </p>
     </fieldset>
@@ -159,15 +169,15 @@ L'élément `<fieldset>`&nbsp;est utilisé pour regroupé plusieurs case à coch
     <fieldset>
         <legend>Un choix multiple avec checkbox</legend>
         <p class="form-item-checkbox">
-            <input class="form-checkbox" type="checkbox" id="cb1" name="cb" value="1" checked="">
-            <label for="cb1">Une réponse possible (selected)</label>
+            <input class="form-checkbox" type="checkbox" id="cb1" name="cb" value="1" checked>
+            <label for="cb1">Une réponse possible (checked)</label>
         </p>
         <p class="form-item-checkbox">
             <input class="form-checkbox" type="checkbox" id="cb2" name="cb" value="2">
             <label for="cb2">Une réponse possible</label>
         </p>
         <p class="form-item-checkbox">
-            <input class="form-checkbox" type="checkbox" id="cb3" name="cb" value="3" disabled="">
+            <input class="form-checkbox" type="checkbox" id="cb3" name="cb" value="3" disabled>
             <label for="br3">Réponse (disabled)</label>
         </p>
     </fieldset>

--- a/src/assets/styleguide/patterns/07-forms.md
+++ b/src/assets/styleguide/patterns/07-forms.md
@@ -1,7 +1,7 @@
 ## Formulaires
 
 ### Champs
-La classe CSS `.form-txt`&nbsp;peut s'appliquer sur les champs texte de type : `text`, `password`, `datetime-local`, `date`, `month`, `time`, `week`, `number`, `email`, `url`, `search`, `tel`, and `color`.
+La classe CSS `.form-txt`&nbsp;peut s'appliquer sur les champs texte de type&nbsp;: `text`, `password`, `datetime-local`, `date`, `month`, `time`, `week`, `number`, `email`, `url`, `search`, `tel`, and `color`.
 
     @example
     <p>Les champs marqués d'un * sont obligatoires</p>
@@ -47,7 +47,7 @@ La classe CSS `.form-txt`&nbsp;peut s'appliquer sur les champs texte de type : `
 
 
 ### Boutons
-Boutons de validation d'un formulaire : `<button type="submit">`, `<input type="submit">`.  
+Boutons de validation d'un formulaire&nbsp;: `<button type="submit">`, `<input type="submit">`.  
 Les classes CSS `.btn-primary`, `.btn-secondary` ou `.btn-tertiary` peuvent être appliquées pour styler ces boutons de formulaire
 
     @example
@@ -87,7 +87,7 @@ Les classes CSS `.btn-primary`, `.btn-secondary` ou `.btn-tertiary` peuvent êtr
 
 
 ### Messages
-Styles pour les 3 états suivants : succès, erreur ou avertissement.
+Styles pour les 3 états suivants&nbsp;: succès, erreur ou avertissement.
 
     @example
     <p class="form-item has-error">

--- a/src/assets/styleguide/patterns/07-forms.md
+++ b/src/assets/styleguide/patterns/07-forms.md
@@ -41,11 +41,26 @@ La classe CSS `.form-txt`&nbsp;peut s'appliquer sur les champs texte de type : `
 
 
 ### Boutons
-Boutons de validation d'un formulaire : `<button type="submit">`, `<input type="submit">`.
+Boutons de validation d'un formulaire : `<button type="submit">`, `<input type="submit">`.  
+Les classes CSS `.btn-primary`, `.btn-secondary` ou `.btn-tertiary` peuvent être appliquées pour styler ces boutons de formulaire
 
     @example
-    <button type="submit" class="btn-primary">Valider</button>
-    <input type="submit" class="btn-primary" value="Valider">
+    p
+      span.inbl.w10 Default:
+      <button type="submit">Valider</button>
+      <input type="submit" value="Valider">
+    p
+      span.inbl.w10 Primary:
+      <button type="submit" class="btn-primary">Valider</button>
+      <input type="submit" class="btn-primary" value="Valider">
+    p
+      span.inbl.w10 Secondary:
+      <button type="submit" class="btn-secondary">Valider</button>
+      <input type="submit" class="btn-secondary" value="Valider">
+    p
+      span.inbl.w10 Tertiary:
+      <button type="submit" class="btn-tertiary">Valider</button>
+      <input type="submit" class="btn-tertiary" value="Valider">
 
 ### Champs "Télécharger"
 

--- a/src/assets/styleguide/patterns/08-grid.md
+++ b/src/assets/styleguide/patterns/08-grid.md
@@ -4,7 +4,8 @@ Le système de grille provient de <a href="https://github.com/alsacreations/KNAC
 
 ### Grilles à colonnes égales (non responsive)
 
-Les grilles de largeurs égales vont de <code>.grid-2</code>&nbsp;à <code>.grid-12</code>. Les classes de grille s'appliquent **sur le parent**  et non sur les enfants.
+Les grilles de largeurs égales vont de <code>.grid-2</code>&nbsp;à <code>.grid-12</code>. Les classes de grille s'appliquent **sur le parent**
+et non sur les enfants.
 
     @example
     <div class="sg-grid grid-2">
@@ -32,7 +33,9 @@ Les grilles de largeurs égales vont de <code>.grid-2</code>&nbsp;à <code>.grid
     
 ### Grilles à colonnes égales responsive
 
-Les grilles de largeurs égales deviennent responsives lorsqu'elles contiennent les mots-clés  <code>-small</code> et/ou <code>-tiny</code>. Les classes de grille s'appliquent **sur le parent**  et non sur les enfants.
+Les grilles de largeurs égales deviennent responsives lorsqu'elles contiennent les mots-clés  <code>-small</code>
+et/ou <code>-tiny</code>. Les classes de grille s'appliquent **sur le parent**
+et non sur les enfants.
 
 Par exemple:
 - `div class="grid-3-tiny-1"` : grille de 3 colonnes égales, puis 1 colonne sur très petit écran


### PR DESCRIPTION
- variables de couleur en syntaxe Sass et plus LESS ($a, plus @a)
- Description de l'utilisation d'un fieldset (et legend)
- exemples et explications pour les liens-comme-des-boutons et les boutons de formulaire (ajout du style par défaut et des 3 primary, secondary et tertiary dans les 2 cas)
- exemple d'input[type="search"] (kikoo Blink/WebKit)
- attribut rows pour textarea, pas row
- l'état des boutons radio et cases à cocher est Checked, pas Selected (le code HTML était OK)
- attribut scope sur les TH des tableaux
- exemple d'abréviation avec 2+ occurences: title que sur la 1èe occurence