### PR TITLE
Images : copier également les sous-répertoires

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -97,7 +97,7 @@ var paths = {
   },
   php: '{,includes/}*.php', // fichiers & dossiers PHP à copier
   fonts: 'assets/css/fonts/', // fichiers typographiques à copier,
-  images: 'assets/{,css/}img/*.{png,jpg,jpeg,gif,svg}', // fichiers images à compresser
+  images: 'assets/{,css/}img/{,*/}*.{png,jpg,jpeg,gif,svg}', // fichiers images à compresser
   misc: '*.{ico,htaccess,txt}', // fichiers divers à copier
   maps: '/maps', // fichiers provenant de sourcemaps
 };


### PR DESCRIPTION
Actuellement la tâche Gulp `img` ne copie que les images à la racine de `.src/assets/img/`. Dans des projets d'une certaine importance, on veut pouvoir organiser ses images dans des sous-répertoires (home, news, etc)